### PR TITLE
Standardize doc, shortdoc, and App name

### DIFF
--- a/lib/mix/tasks/dialyze.ex
+++ b/lib/mix/tasks/dialyze.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Dialyze do
   @moduledoc """
-  Analyse the current mix project using success typing.
+  Analyses the current Mix project using success typing.
 
   ## Examples
 
@@ -33,9 +33,9 @@ defmodule Mix.Tasks.Dialyze do
       mix deps.get
       # Possibly make changes to current application and then compile project
       mix compile
-      # Run dialyze for the first time to build a PLT and analyse
+      # Run Dialyze for the first time to build a PLT and analyse
       mix dialyze
-      # Fix dialyzer warnings and analyse again (assuming same build
+      # Fix Dialyzer warnings and analyse again (assuming same build
       # environment, Elixir version, Erlang version and deps)
       mix dialyze --no-check
 
@@ -62,7 +62,7 @@ defmodule Mix.Tasks.Dialyze do
   `http://www.erlang.org/doc/apps/dialyzer/index.html`
   """
 
-  @shortdoc "Analyse the current mix project using success typing"
+  @shortdoc "Analyses the current Mix project using success typing"
 
   use Mix.Task
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Dialyze.Mixfile do
     [app: :dialyze,
      version: "0.2.0",
      elixir: "~> 0.14.3 or ~> 0.15.0 or ~> 1.0",
-     description: "Dialyzer mix task",
+     description: "Dialyzer Mix task",
      deps: [],
      aliases: [install: ["compile", "archive.build", "archive.install --force"]],
      package: package()]


### PR DESCRIPTION
The verb describing the summary of the module is preferred in present continuous,
and the name of the app in title case.

To make it unified with the rest of the messages when you run `mix help` and  `mix help dialyze`